### PR TITLE
Optimized the Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ services:
   - docker
 
 script:
-  - docker build -t dp .
+  - docker build -t cmso/biotracks .
+  - docker run cmso/biotracks
 
 deploy:
    provider: pypi

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,20 @@ RUN true \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& true
 
-COPY . /src
+# Copy requirements.txt first (they are unlikely to change)
+# and install deps right after, so they are cached.
+COPY requirements.txt /src/
 WORKDIR /src
+RUN true \
+	&& pip install -r requirements.txt \
+	&& pip install pytest \
+	&& true
+
+# Copy the rest of the project.
+COPY . /src
 
 RUN true \
 	&& adduser dp \
-	&& pip install -r requirements.txt \
-	&& pip install pytest \
 	&& python setup.py install \
 	&& chown -R dp:dp /src \
 	&& true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,27 @@ FROM continuumio/miniconda3
 # https://www.continuum.io/blog/developer-blog/anaconda-and-docker-better-together-reproducible-data-science
 #  docker run -i -t -p 8888:8888 continuumio/anaconda3 /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir /opt/notebooks && /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser"
 
+RUN true \
+	&& pip install --upgrade pip \
+	&& conda install -y matplotlib \
+	&& true
 
-RUN apt-get update && apt-get install -y build-essential
-RUN pip install --upgrade pip
-RUN conda install -y matplotlib
-RUN pip install datapackage jsontableschema jsontableschema-pandas
-RUN pip install pytest
-RUN adduser dp
+RUN true \
+	&& apt-get update \
+	&& apt-get install -y make \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& true
+
 COPY . /src
 WORKDIR /src
-RUN python setup.py install
-RUN chown -R dp:dp /src
+
+RUN true \
+	&& adduser dp \
+	&& pip install -r requirements.txt \
+	&& pip install pytest \
+	&& python setup.py install \
+	&& chown -R dp:dp /src \
+	&& true
+
 USER dp
-RUN make test
+CMD ["make", "test"]


### PR DESCRIPTION
I propose the following changes to the Dockerfile:

- Install matplotlib using conda first (as it takes most of time).
- Don't install build-essentials, as it is not needed (pip downloads wheels from PyPi, so no compilation is needed).
- Remove cached folders after installing using apt (as suggested by https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices#RUN).
- Install deps using requirements.txt.
- Change formatting so lines can be easily moved between RUN statements.