### PR TITLE
Specs compliance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,5 @@ RUN true \
 	&& true
 
 USER dp
+RUN find examples -name '*.json' -print0 | xargs -n 1 -0 python scripts/validate_dpkg.py
 CMD ["make", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ RUN true \
 	&& true
 
 USER dp
-RUN find examples -name '*.json' -print0 | xargs -n 1 -0 python scripts/validate_dpkg.py
+RUN find examples -name '*.json' -print0 | xargs -n 1 -0 python scripts/validate_dpkg.py --log-level=DEBUG
 CMD ["make", "test"]

--- a/biotracks/createdp.py
+++ b/biotracks/createdp.py
@@ -27,10 +27,14 @@
 import csv
 import io
 import os
+import re
 
 import datapackage as dp
 from jsontableschema import infer
 from .names import OBJECTS_TABLE_NAME, LINKS_TABLE_NAME
+
+
+NAME_PATTERN = re.compile(r"^[a-z0-9_.-]+$")
 
 
 def create_dpkg(top_level_dict, dict_, directory, joint_id):
@@ -42,6 +46,12 @@ def create_dpkg(top_level_dict, dict_, directory, joint_id):
     directory -- the directory
     joint_id -- the joint_identifier
     """
+    try:
+        name = top_level_dict["name"]
+    except KeyError:
+        raise ValueError("'name' is a required property")
+    if not NAME_PATTERN.match(name):
+        raise ValueError("invalid name: %r" % (name,))
 
     myDP = dp.DataPackage()
 

--- a/biotracks/createdp.py
+++ b/biotracks/createdp.py
@@ -34,6 +34,7 @@ from jsontableschema import infer
 from .names import OBJECTS_TABLE_NAME, LINKS_TABLE_NAME
 
 
+# https://specs.frictionlessdata.io/data-package/#metadata
 NAME_PATTERN = re.compile(r"^[a-z0-9_.-]+$")
 
 

--- a/biotracks/validation.py
+++ b/biotracks/validation.py
@@ -1,0 +1,168 @@
+# #%L
+# Copyright (c) 2016-2017 Cell Migration Standardisation Organization
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+
+import datapackage
+import datapackage.registry
+import datapackage.exceptions
+
+from . import names
+from .utils import get_logger
+
+
+REQUIRED_FIELDS = {
+    names.OBJECTS_TABLE_NAME: {names.OBJECT_NAME, names.FRAME_NAME,
+                               names.X_COORD_NAME, names.Y_COORD_NAME},
+    names.LINKS_TABLE_NAME: {names.LINK_NAME, names.OBJECT_NAME},
+    names.TRACKS_TABLE_NAME: {names.TRACK_NAME, names.LINK_NAME},
+}
+
+FOREIGN_KEYS = [
+    {"fields": names.OBJECT_NAME,
+     "reference": {"fields": names.OBJECT_NAME,
+                   "resource": names.OBJECTS_TABLE_NAME}}
+]
+
+
+def is_tabular(dp):
+    if not isinstance(dp, datapackage.DataPackage):
+        return False
+    reg = datapackage.registry.Registry()
+    return dp.schema.to_dict() == reg.get('tabular')
+
+
+class ValidationError(datapackage.exceptions.ValidationError):
+    pass
+
+
+class Validator(object):
+
+    def __init__(self, log_level=None):
+        self.logger = get_logger(self.__class__.__name__, level=log_level)
+
+    def validate(self, dp):
+        if isinstance(dp, datapackage.DataPackage) and not is_tabular(dp):
+            raise ValueError("data package must be a tabular data package")
+        else:
+            dp = datapackage.DataPackage(dp, schema="tabular")
+        dp.validate()
+        self.logger.debug("valid tabular data package")
+        if len(dp.resources) < 2:
+            self.__error("data package must have at least two resources")
+        res_map = dict((_.descriptor['name'], _) for _ in dp.resources)
+        try:
+            objects = res_map[names.OBJECTS_TABLE_NAME]
+        except KeyError:
+            self.__error("objects table not found")
+        else:
+            self.validate_objects(objects.descriptor)
+        try:
+            links = res_map[names.LINKS_TABLE_NAME]
+        except KeyError:
+            self.__error("links table not found")
+        else:
+            self.validate_links(links.descriptor)
+        try:
+            tracks = res_map[names.TRACKS_TABLE_NAME]
+        except KeyError:
+            pass
+        else:
+            self.validate_tracks(tracks.descriptor)
+
+    def validate_objects(self, objects):
+        try:
+            pk = objects["schema"]["primaryKey"]
+        except KeyError:
+            self.__error("objects table schema has no primary key")
+        if pk != names.OBJECT_NAME:
+            self.__error(
+                "objects table primary key must be %r" % (names.OBJECT_NAME,)
+            )
+        by_name = self.__check_required_fields(objects)
+        id_field = by_name[names.OBJECT_NAME]
+        try:
+            constraints = id_field["constraints"]
+        except KeyError:
+            self.__error("object id field has no constraints")
+        try:
+            unique = constraints["unique"]
+        except KeyError:
+            self.__error("object id constraints: missing 'unique' property")
+        if not unique:
+            self.__error("object id constraints: 'unique' property is false")
+
+    def validate_links(self, links):
+        try:
+            fk = links["schema"]["foreignKeys"]
+        except KeyError:
+            self.__error("objects table schema has no foreign keys")
+        self.validate_foreign_keys(fk)
+        self.__check_required_fields(links)
+
+    def validate_tracks(self, tracks):
+        self.__check_required_fields(tracks)
+
+    def validate_foreign_keys(self, fk):
+        if len(fk) != 1:
+            self.__error("links table must have exactly one foreign key")
+        fk = fk[0]
+        try:
+            fields = fk["fields"]
+            ref = fk["reference"]
+        except KeyError as e:
+            self.__error("missing property in foreignKeys: %r" % e.args)
+        if fields != names.OBJECT_NAME:
+            self.__error(
+                "foreignKeys fields must be %r" % (names.OBJECT_NAME,)
+            )
+        try:
+            ref_fields = ref["fields"]
+            ref_res = ref["resource"]
+        except KeyError as e:
+            self.__error(
+                "missing property in foreignKeys reference: %r" % e.args
+            )
+        if ref_fields != names.OBJECT_NAME:
+            self.__error(
+                "foreignKeys ref fields must be %r" % (names.OBJECT_NAME,)
+            )
+        if ref_res != names.OBJECTS_TABLE_NAME:
+            self.__error(
+                "foreignKeys ref resource must be %r" % (
+                    names.OBJECTS_TABLE_NAME,)
+            )
+
+    def __check_required_fields(self, descriptor):
+        required = REQUIRED_FIELDS[descriptor['name']]
+        by_name = dict((_['name'], _) for _ in descriptor['schema']['fields'])
+        if not required <= set(by_name):
+            self.__error(
+                "required fields for %s: %r" % (descriptor['name'], required)
+            )
+        return by_name
+
+    def __error(self, msg):
+        self.logger.error(msg)
+        raise ValidationError(msg)

--- a/scripts/validate_dpkg.py
+++ b/scripts/validate_dpkg.py
@@ -1,0 +1,64 @@
+# #%L
+# Copyright (c) 2016-2017 Cell Migration Standardisation Organization
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+
+"""\
+Validate a CMSO datapackage.
+"""
+
+import os
+import sys
+import argparse
+
+import datapackage
+
+from biotracks.validation import Validator
+from biotracks.utils import get_log_level, get_logger
+
+
+def log_level(s):
+    try:
+        return get_log_level(s)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(e.message)
+
+
+def make_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('dp_fn', metavar="JSON_FILE")
+    parser.add_argument('--log-level', metavar='LEVEL', type=log_level,
+                        default='INFO', help='logging level')
+    return parser
+
+
+def main(argv):
+    parser = make_parser()
+    args = parser.parse_args(argv[1:])
+    validator = Validator(log_level=args.log_level)
+    validator.validate(args.dp_fn)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/validate_dpkg.py
+++ b/scripts/validate_dpkg.py
@@ -28,14 +28,11 @@
 Validate a CMSO datapackage.
 """
 
-import os
 import sys
 import argparse
 
-import datapackage
-
 from biotracks.validation import Validator
-from biotracks.utils import get_log_level, get_logger
+from biotracks.utils import get_log_level
 
 
 def log_level(s):

--- a/scripts/validate_dpkg.py
+++ b/scripts/validate_dpkg.py
@@ -32,7 +32,7 @@ import sys
 import argparse
 
 from biotracks.validation import Validator
-from biotracks.utils import get_log_level
+from biotracks.utils import get_log_level, get_logger
 
 
 def log_level(s):
@@ -53,8 +53,10 @@ def make_parser():
 def main(argv):
     parser = make_parser()
     args = parser.parse_args(argv[1:])
+    logger = get_logger('validate_dpkg', level=args.log_level, f=sys.stdout)
     validator = Validator(log_level=args.log_level)
     validator.validate(args.dp_fn)
+    logger.debug("%r: OK" % (args.dp_fn))
 
 
 if __name__ == "__main__":

--- a/tests/test_createdp.py
+++ b/tests/test_createdp.py
@@ -66,3 +66,6 @@ class TestCreatedp(object):
         tld = d['conf']['TOP_LEVEL_INFO']
         dp = createdp.create_dpkg(tld, {}, d['dp_dir'], names.OBJECT_NAME)
         assert dp.to_dict() == d['dp'].to_dict()
+        tld['name'] = "CMSO_TRACKS"
+        with pytest.raises(ValueError):
+            createdp.create_dpkg(tld, {}, d['dp_dir'], names.OBJECT_NAME)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -35,6 +35,7 @@ from biotracks import validation, names
 
 OBJECTS_PATH = "objects.csv"
 LINKS_PATH = "links.csv"
+TRACKS_PATH = "tracks.csv"
 JSON = {
     "name": names.PACKAGE_NAME,
     "resources": [
@@ -164,6 +165,27 @@ class TestValidation(object):
         for k in "fields", "resource":
             d = deepcopy(JSON)
             d["resources"][i]["schema"]["foreignKeys"][0]["reference"][k] = ""
+            self.__assert_raises(dp(d))
+
+    def test_tracks(self, dp):
+        tracks_res = {
+            "name": names.TRACKS_TABLE_NAME,
+            "path": TRACKS_PATH,
+            "schema": {
+                "fields": [
+                    {"name": names.TRACK_NAME},
+                    {"name": names.LINK_NAME},
+                ],
+            },
+        }
+        d = deepcopy(JSON)
+        d["resources"].append(tracks_res)
+        validation.Validator().validate(dp(d))
+        for i in range(len(tracks_res["schema"]["fields"])):
+            d = deepcopy(JSON)
+            r = deepcopy(tracks_res)
+            del r["schema"]["fields"][i]
+            d["resources"].append(r)
             self.__assert_raises(dp(d))
 
     def __res_by_name(self, name):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,175 @@
+# #%L
+# Copyright (c) 2016-2017 Cell Migration Standardisation Organization
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+
+import json
+import csv
+from copy import deepcopy
+
+import pytest
+from datapackage.exceptions import ValidationError
+
+from biotracks import validation, names
+
+OBJECTS_PATH = "objects.csv"
+LINKS_PATH = "links.csv"
+JSON = {
+    "name": names.PACKAGE_NAME,
+    "resources": [
+        {
+            "name": names.OBJECTS_TABLE_NAME,
+            "path": OBJECTS_PATH,
+            "schema": {
+                "fields": [
+                    {"name": names.OBJECT_NAME,
+                     "constraints": {"unique": True}},
+                    {"name": names.FRAME_NAME},
+                    {"name": names.X_COORD_NAME},
+                    {"name": names.Y_COORD_NAME},
+                ],
+                "primaryKey": names.OBJECT_NAME,
+            }
+        },
+        {
+            "name": names.LINKS_TABLE_NAME,
+            "path": LINKS_PATH,
+            "schema": {
+                "fields": [{"name": names.LINK_NAME},
+                           {"name": names.OBJECT_NAME}],
+                "foreignKeys": [
+                    {"fields": names.OBJECT_NAME,
+                     "reference": {"fields": names.OBJECT_NAME,
+                                   "resource": names.OBJECTS_TABLE_NAME}}
+                ]
+            }
+        }
+    ]
+}
+
+CSV = {
+    OBJECTS_PATH: [
+        [names.OBJECT_NAME, names.FRAME_NAME,
+         names.X_COORD_NAME, names.Y_COORD_NAME],
+        [0, 1, 0.4, 0.5],
+        [1, 2, 0.5, 0.6],
+    ],
+    LINKS_PATH: [
+        [names.LINK_NAME, names.OBJECT_NAME],
+        [0, 0],
+        [0, 1],
+    ],
+}
+
+
+@pytest.fixture()
+def dp(tmpdir):
+    def make_dp(descriptor):
+        json_path = tmpdir.join("dp.json")
+        with json_path.open("w") as f:
+            json.dump(descriptor, f)
+        for name, content in CSV.items():
+            with tmpdir.join(name).open("w") as f:
+                csv.writer(f).writerows(content)
+        return str(json_path)
+    yield make_dp
+    tmpdir.remove(rec=True)
+
+
+class TestValidation(object):
+
+    def test_validation(self, dp):
+        validation.Validator().validate(dp(JSON))
+
+    def test_no_name(self, dp):
+        d = deepcopy(JSON)
+        del d["name"]
+        self.__assert_raises(dp(d))
+
+    def test_no_resources(self, dp):
+        d = deepcopy(JSON)
+        del d["resources"]
+        self.__assert_raises(dp(d))
+
+    def test_bad_name(self, dp):
+        d = deepcopy(JSON)
+        d["name"] = d["name"].upper()
+        self.__assert_raises(dp(d))
+
+    def test_missing_resource(self, dp):
+        for i in range(len(JSON["resources"])):
+            d = deepcopy(JSON)
+            del d["resources"][i]
+            self.__assert_raises(dp(d))
+
+    def test_missing_field(self, dp):
+        for i, res in enumerate(JSON["resources"]):
+            for j in range(len(res["schema"]["fields"])):
+                d = deepcopy(JSON)
+                del d["resources"][i]["schema"]["fields"][j]
+                self.__assert_raises(dp(d))
+
+    def test_primary_key(self, dp):
+        obj_i, obj_res = self.__res_by_name(names.OBJECTS_TABLE_NAME)
+        d = deepcopy(JSON)
+        del d["resources"][obj_i]["schema"]["primaryKey"]
+        self.__assert_raises(dp(d))
+        d = deepcopy(JSON)
+        d["resources"][obj_i]["schema"]["primaryKey"] = "foobar"
+        self.__assert_raises(dp(d))
+
+    def test_constraints(self, dp):
+        i, r = self.__res_by_name(names.OBJECTS_TABLE_NAME)
+        j = [_ for (_, f) in enumerate(r["schema"]["fields"])
+             if f["name"] == names.OBJECT_NAME][0]
+        d = deepcopy(JSON)
+        del d["resources"][i]["schema"]["fields"][j]["constraints"]
+        self.__assert_raises(dp(d))
+        d = deepcopy(JSON)
+        d["resources"][i]["schema"]["fields"][j]["constraints"] = {}
+        self.__assert_raises(dp(d))
+        d = deepcopy(JSON)
+        d["resources"][i]["schema"]["fields"][j]["constraints"]["unique"] = 0
+        self.__assert_raises(dp(d))
+
+    def test_foreign_keys(self, dp):
+        i, r = self.__res_by_name(names.LINKS_TABLE_NAME)
+        d = deepcopy(JSON)
+        del d["resources"][i]["schema"]["foreignKeys"]
+        self.__assert_raises(dp(d))
+        d = deepcopy(JSON)
+        d["resources"][i]["schema"]["foreignKeys"][0]["fields"] = ""
+        self.__assert_raises(dp(d))
+        for k in "fields", "resource":
+            d = deepcopy(JSON)
+            d["resources"][i]["schema"]["foreignKeys"][0]["reference"][k] = ""
+            self.__assert_raises(dp(d))
+
+    def __res_by_name(self, name):
+        return [(i, r) for (i, r) in enumerate(JSON["resources"])
+                if r["name"] == name][0]
+
+    def __assert_raises(self, dp_fn):
+        with pytest.raises(ValidationError):
+            validation.Validator().validate(dp_fn)


### PR DESCRIPTION
Addresses #3.

**SUMMARY:**

* Adds a validation module for CMSO-specific tabular data packages. The validation process first checks that the data package is a valid tabular data package via the Frictionless API, then performs several additional checks to verify that it's also a valid CMSO data package (and implicitly defines our specs, since they have not been formalized yet).
* Checks that the package name provided via the top-level configuration section respects the Frictionless constraints (lowercase alphanumeric characters plus `._-`). Since 1) the top-level section is the only "external" source of metadata and 2) the `"name"` property is the only one with special requirements, this should ensure that data packages we write are always specs-compliant (barring mistakes in our code, ofc).
* Adds a validation script and a command that validates all data packages in our examples to the Docker build (and thus to the Travis build).

**TESTING:**

Check that the build is green and that the newly added tests and checks have been executed in the Travis log.

**NOTES:**

* The proper way to implement CMSO datapackage validation would be to define our own JSON schema for it (for instance, see the [fiscal data package schema](https://github.com/frictionlessdata/datapackage-py/blob/master/datapackage/profiles/fiscal-data-package.json)) and then simply use the standard Frictionless validation engine. However: 1) this is out of the scope of the current milestone and 2) Frictionless specs are currently undergoing a major change, so it's probably best to wait until they stabilize.

* We are currently validating using the stable Python data package API (`0.x`), [which uses pre-1.0 specs](https://github.com/frictionlessdata/datapackage-py/issues/149#issuecomment-312431476), but we should keep an eye on the upcoming 1.0 specs. In particular, naming the JSON file `datapackage.json` is going to be a requirement (see http://specs.frictionlessdata.io/data-package/).
