### PR TITLE
Rename names

### DIFF
--- a/biotracks/cmso.py
+++ b/biotracks/cmso.py
@@ -24,16 +24,20 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # #L%
 
-PACKAGE_NAME = "cmso_tracks"
+"""\
+Define standard property names used in CMSO data packages.
+"""
 
-OBJECTS_TABLE_NAME = "cmso_objects_table"
-LINKS_TABLE_NAME = "cmso_links_table"
-TRACKS_TABLE_NAME = "cmso_tracks_table"
+PACKAGE = "cmso_tracks"
 
-X_COORD_NAME = "cmso_x_coord"
-Y_COORD_NAME = "cmso_y_coord"
-Z_COORD_NAME = "cmso_z_coord"
-FRAME_NAME = "cmso_frame_id"
-OBJECT_NAME = "cmso_object_id"
-LINK_NAME = "cmso_link_id"
-TRACK_NAME = "cmso_track_id"
+OBJECTS_TABLE = "cmso_objects_table"
+LINKS_TABLE = "cmso_links_table"
+TRACKS_TABLE = "cmso_tracks_table"
+
+X_COORD = "cmso_x_coord"
+Y_COORD = "cmso_y_coord"
+Z_COORD = "cmso_z_coord"
+FRAME_ID = "cmso_frame_id"
+OBJECT_ID = "cmso_object_id"
+LINK_ID = "cmso_link_id"
+TRACK_ID = "cmso_track_id"

--- a/biotracks/createdp.py
+++ b/biotracks/createdp.py
@@ -31,7 +31,7 @@ import re
 
 import datapackage as dp
 from jsontableschema import infer
-from .names import OBJECTS_TABLE_NAME, LINKS_TABLE_NAME
+from . import cmso
 
 
 # https://specs.frictionlessdata.io/data-package/#metadata
@@ -71,7 +71,7 @@ def create_dpkg(top_level_dict, dict_, directory, joint_id):
                        primary_key=joint_id)
 
     myDP.descriptor['resources'].append(
-        {"name": OBJECTS_TABLE_NAME,
+        {"name": cmso.OBJECTS_TABLE,
          "path": path,
          "schema": schema,
          }
@@ -88,13 +88,13 @@ def create_dpkg(top_level_dict, dict_, directory, joint_id):
             "fields": joint_id,
             "reference": {
                 "datapackage": "",
-                "resource": OBJECTS_TABLE_NAME,
+                "resource": cmso.OBJECTS_TABLE,
                 "fields": joint_id
             }
         }]
 
     myDP.descriptor['resources'].append(
-        {"name": LINKS_TABLE_NAME,
+        {"name": cmso.LINKS_TABLE,
          "path": path,
          "schema": schema,
          }

--- a/biotracks/readfile.py
+++ b/biotracks/readfile.py
@@ -31,10 +31,7 @@ import pandas as pd
 import xlrd
 
 from .utils import get_logger
-from .names import (
-    X_COORD_NAME, Y_COORD_NAME, Z_COORD_NAME,
-    FRAME_NAME, OBJECT_NAME, LINK_NAME
-)
+from . import cmso
 
 
 class TracksReader(object):
@@ -56,7 +53,7 @@ class TrackMateReader(TracksReader):
         spots_dict = self.read_spots()
         objects_df = pd.DataFrame(
             [[k, v[0], v[1], v[2]] for k, v in spots_dict.items()],
-            columns=[OBJECT_NAME, FRAME_NAME, X_COORD_NAME, Y_COORD_NAME]
+            columns=[cmso.OBJECT_ID, cmso.FRAME_ID, cmso.X_COORD, cmso.Y_COORD]
         )
         ordered_edges_df = self.read_edges(spots_dict)
         links_df = self.read_links(ordered_edges_df)
@@ -200,17 +197,17 @@ class TrackMateReader(TracksReader):
         for key, value in links_dict_unique.items():
             for spot in value:
                 links_df = links_df.append([[key, spot]], ignore_index=True)
-        links_df.columns = [LINK_NAME, OBJECT_NAME]
+        links_df.columns = [cmso.LINK_ID, cmso.OBJECT_ID]
         return links_df
 
 
 class CellProfilerReader(TracksReader):
 
     def read(self):
-        self.x = self.conf.get(X_COORD_NAME)
-        self.y = self.conf.get(Y_COORD_NAME)
-        self.frame = self.conf.get(FRAME_NAME)
-        self.obj_id = self.conf.get(OBJECT_NAME)
+        self.x = self.conf.get(cmso.X_COORD)
+        self.y = self.conf.get(cmso.Y_COORD)
+        self.frame = self.conf.get(cmso.FRAME_ID)
+        self.obj_id = self.conf.get(cmso.OBJECT_ID)
         # parse the digits used for the tracking settings (e.g. 15)
         digits = self.x.split('_')[2]
         self.track_id = 'TrackObjects_Label_' + digits
@@ -234,7 +231,7 @@ class CellProfilerReader(TracksReader):
                 columns=[self.obj_id, self.frame, self.x, self.y]
             )
         objects_df.columns = [
-            OBJECT_NAME, FRAME_NAME, X_COORD_NAME, Y_COORD_NAME
+            cmso.OBJECT_ID, cmso.FRAME_ID, cmso.X_COORD, cmso.Y_COORD
         ]
         return cp_df, objects_df
 
@@ -270,7 +267,7 @@ class CellProfilerReader(TracksReader):
         for key, value in links_dict.items():
             for object_ in value:
                 links_df = links_df.append([[key, object_]])
-        links_df.columns = [LINK_NAME, OBJECT_NAME]
+        links_df.columns = [cmso.LINK_ID, cmso.OBJECT_ID]
         return links_df
 
 
@@ -293,11 +290,10 @@ class IcyReader(TracksReader):
         obj_df = pd.DataFrame(
             objects, columns=['OBJECT_ID', 't', 'x', 'y', 'z']
         )
-        obj_df.columns = [
-            OBJECT_NAME, FRAME_NAME, X_COORD_NAME, Y_COORD_NAME, Z_COORD_NAME
-        ]
+        obj_df.columns = [cmso.OBJECT_ID, cmso.FRAME_ID, cmso.X_COORD,
+                          cmso.Y_COORD, cmso.Z_COORD]
         links_df = pd.DataFrame(links, columns=['LINK_ID', 'OBJECT_ID'])
-        links_df.columns = [LINK_NAME, OBJECT_NAME]
+        links_df.columns = [cmso.LINK_ID, cmso.OBJECT_ID]
         return obj_df, links_df
 
 
@@ -308,17 +304,16 @@ class CellmiaReader(TracksReader):
 
     def read(self):
         cellmia_link_id = "ID of track"
-        x = self.conf.get(X_COORD_NAME)
-        y = self.conf.get(Y_COORD_NAME)
-        frame_id = self.conf.get(FRAME_NAME)
+        x = self.conf.get(cmso.X_COORD)
+        y = self.conf.get(cmso.Y_COORD)
+        frame_id = self.conf.get(cmso.FRAME_ID)
         df = pd.read_csv(self.fname, sep=self.SEP, encoding=self.ENCODING,
                          usecols=[cellmia_link_id, frame_id, x, y])
         df.reset_index(inplace=True)
-        df.columns = [
-            OBJECT_NAME, LINK_NAME, FRAME_NAME, X_COORD_NAME, Y_COORD_NAME
-        ]
-        obj_df = df.drop(LINK_NAME, 1)
-        links_df = df.drop([FRAME_NAME, X_COORD_NAME, Y_COORD_NAME], 1)
+        df.columns = [cmso.OBJECT_ID, cmso.LINK_ID, cmso.FRAME_ID,
+                      cmso.X_COORD, cmso.Y_COORD]
+        obj_df = df.drop(cmso.LINK_ID, 1)
+        links_df = df.drop([cmso.FRAME_ID, cmso.X_COORD, cmso.Y_COORD], 1)
         return obj_df, links_df
 
 

--- a/biotracks/validation.py
+++ b/biotracks/validation.py
@@ -28,21 +28,22 @@ import datapackage
 import datapackage.registry
 import datapackage.exceptions
 
-from . import names
+from . import cmso
 from .utils import get_logger
 
 
 REQUIRED_FIELDS = {
-    names.OBJECTS_TABLE_NAME: {names.OBJECT_NAME, names.FRAME_NAME,
-                               names.X_COORD_NAME, names.Y_COORD_NAME},
-    names.LINKS_TABLE_NAME: {names.LINK_NAME, names.OBJECT_NAME},
-    names.TRACKS_TABLE_NAME: {names.TRACK_NAME, names.LINK_NAME},
+    cmso.OBJECTS_TABLE: {
+        cmso.OBJECT_ID, cmso.FRAME_ID, cmso.X_COORD, cmso.Y_COORD
+    },
+    cmso.LINKS_TABLE: {cmso.LINK_ID, cmso.OBJECT_ID},
+    cmso.TRACKS_TABLE: {cmso.TRACK_ID, cmso.LINK_ID},
 }
 
 FOREIGN_KEYS = [
-    {"fields": names.OBJECT_NAME,
-     "reference": {"fields": names.OBJECT_NAME,
-                   "resource": names.OBJECTS_TABLE_NAME}}
+    {"fields": cmso.OBJECT_ID,
+     "reference": {"fields": cmso.OBJECT_ID,
+                   "resource": cmso.OBJECTS_TABLE}}
 ]
 
 
@@ -73,19 +74,19 @@ class Validator(object):
             self.__error("data package must have at least two resources")
         res_map = dict((_.descriptor['name'], _) for _ in dp.resources)
         try:
-            objects = res_map[names.OBJECTS_TABLE_NAME]
+            objects = res_map[cmso.OBJECTS_TABLE]
         except KeyError:
             self.__error("objects table not found")
         else:
             self.validate_objects(objects.descriptor)
         try:
-            links = res_map[names.LINKS_TABLE_NAME]
+            links = res_map[cmso.LINKS_TABLE]
         except KeyError:
             self.__error("links table not found")
         else:
             self.validate_links(links.descriptor)
         try:
-            tracks = res_map[names.TRACKS_TABLE_NAME]
+            tracks = res_map[cmso.TRACKS_TABLE]
         except KeyError:
             pass
         else:
@@ -96,12 +97,12 @@ class Validator(object):
             pk = objects["schema"]["primaryKey"]
         except KeyError:
             self.__error("objects table schema has no primary key")
-        if pk != names.OBJECT_NAME:
+        if pk != cmso.OBJECT_ID:
             self.__error(
-                "objects table primary key must be %r" % (names.OBJECT_NAME,)
+                "objects table primary key must be %r" % (cmso.OBJECT_ID,)
             )
         by_name = self.__check_required_fields(objects)
-        id_field = by_name[names.OBJECT_NAME]
+        id_field = by_name[cmso.OBJECT_ID]
         try:
             constraints = id_field["constraints"]
         except KeyError:
@@ -133,9 +134,9 @@ class Validator(object):
             ref = fk["reference"]
         except KeyError as e:
             self.__error("missing property in foreignKeys: %r" % e.args)
-        if fields != names.OBJECT_NAME:
+        if fields != cmso.OBJECT_ID:
             self.__error(
-                "foreignKeys fields must be %r" % (names.OBJECT_NAME,)
+                "foreignKeys fields must be %r" % (cmso.OBJECT_ID,)
             )
         try:
             ref_fields = ref["fields"]
@@ -144,14 +145,13 @@ class Validator(object):
             self.__error(
                 "missing property in foreignKeys reference: %r" % e.args
             )
-        if ref_fields != names.OBJECT_NAME:
+        if ref_fields != cmso.OBJECT_ID:
             self.__error(
-                "foreignKeys ref fields must be %r" % (names.OBJECT_NAME,)
+                "foreignKeys ref fields must be %r" % (cmso.OBJECT_ID,)
             )
-        if ref_res != names.OBJECTS_TABLE_NAME:
+        if ref_res != cmso.OBJECTS_TABLE:
             self.__error(
-                "foreignKeys ref resource must be %r" % (
-                    names.OBJECTS_TABLE_NAME,)
+                "foreignKeys ref resource must be %r" % (cmso.OBJECTS_TABLE,)
             )
 
     def __check_required_fields(self, descriptor):

--- a/scripts/create_dpkg.py
+++ b/scripts/create_dpkg.py
@@ -42,7 +42,7 @@ import biotracks.createdp as createdp
 import biotracks.plot as plot
 import biotracks.pushtopandas as pushtopandas
 import biotracks.readfile as readfile
-import biotracks.names as names
+import biotracks.cmso as cmso
 from biotracks.utils import get_log_level, get_logger
 
 
@@ -83,7 +83,7 @@ def main(argv):
         logger.info('Trying default config file location: "%s"', args.config)
     if not os.path.isfile(args.config):
         logger.info('Config file not present, using defaults')
-        top_level_dict = {'name': names.PACKAGE_NAME}
+        top_level_dict = {'name': cmso.PACKAGE}
         track_dict = {}
     else:
         conf = configparser.ConfigParser()
@@ -91,9 +91,9 @@ def main(argv):
         top_level_dict = conf['TOP_LEVEL_INFO']
         track_dict = conf['TRACKING_DATA']
 
-    joint_id = names.OBJECT_NAME
-    link_id = names.LINK_NAME
-    track_id = names.TRACK_NAME
+    joint_id = cmso.OBJECT_ID
+    link_id = cmso.LINK_ID
+    track_id = cmso.TRACK_ID
 
     # read file - returns a dictionary with objects and links
     dict_ = readfile.read_file(
@@ -134,9 +134,9 @@ def main(argv):
         objects_links, tracks, how='outer', on=link_id
     )
 
-    x = names.X_COORD_NAME
-    y = names.Y_COORD_NAME
-    frame = names.FRAME_NAME
+    x = cmso.X_COORD
+    y = cmso.Y_COORD
+    frame = cmso.FRAME_ID
     # basic visualizations
     objects_links_tracks.sort_values(frame, axis=0, inplace=True)
     cum_df = plot.compute_cumulative_displacements(

--- a/tests/test_createdp.py
+++ b/tests/test_createdp.py
@@ -30,7 +30,7 @@ import configparser
 import datapackage
 import pytest
 
-from biotracks import createdp, names
+from biotracks import createdp, cmso
 from .common import EXAMPLES_DIR, RELPATHS
 
 
@@ -64,8 +64,8 @@ class TestCreatedp(object):
 
     def __check_dps(self, d):
         tld = d['conf']['TOP_LEVEL_INFO']
-        dp = createdp.create_dpkg(tld, {}, d['dp_dir'], names.OBJECT_NAME)
+        dp = createdp.create_dpkg(tld, {}, d['dp_dir'], cmso.OBJECT_ID)
         assert dp.to_dict() == d['dp'].to_dict()
         tld['name'] = "CMSO_TRACKS"
         with pytest.raises(ValueError):
-            createdp.create_dpkg(tld, {}, d['dp_dir'], names.OBJECT_NAME)
+            createdp.create_dpkg(tld, {}, d['dp_dir'], cmso.OBJECT_ID)

--- a/tests/test_pushtopandas.py
+++ b/tests/test_pushtopandas.py
@@ -30,7 +30,7 @@ import configparser
 import pandas as pd
 import pytest
 
-from biotracks import names
+from biotracks import cmso
 from biotracks.pushtopandas import push_to_pandas
 from .common import (
     EXAMPLES_DIR, RELPATHS, get_obj_dict, get_link_dict, get_track_dict
@@ -69,9 +69,9 @@ class TestPushToPandas(object):
         self.__check_dicts(data('TrackMate'))
 
     def __check_dicts(self, d):
-        obj_id = names.OBJECT_NAME
-        link_id = names.LINK_NAME
-        track_id = names.TRACK_NAME
+        obj_id = cmso.OBJECT_ID
+        link_id = cmso.LINK_ID
+        track_id = cmso.TRACK_ID
         ret = push_to_pandas(d['dp_dir'], obj_id)
         exp_track_dict = get_track_dict(d['tracks_df'], link_id, track_id)
         track_dict = get_track_dict(ret['tracks'], link_id, track_id)

--- a/tests/test_readfile.py
+++ b/tests/test_readfile.py
@@ -30,7 +30,7 @@ import configparser
 import pandas as pd
 import pytest
 
-from biotracks import readfile, names
+from biotracks import readfile, cmso
 from .common import EXAMPLES_DIR, RELPATHS, get_obj_dict, get_link_dict
 
 
@@ -67,7 +67,7 @@ class TestReadFile(object):
         self.__check_dicts(data('TrackMate'))
 
     def __check_dicts(self, d):
-        obj_id, link_id = names.OBJECT_NAME, names.LINK_NAME
+        obj_id, link_id = cmso.OBJECT_ID, cmso.LINK_ID
         exp_link_dict = get_link_dict(
             pd.read_csv(d['links_path']), obj_id, link_id
         )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -31,38 +31,38 @@ from copy import deepcopy
 import pytest
 from datapackage.exceptions import ValidationError
 
-from biotracks import validation, names
+from biotracks import validation, cmso
 
 OBJECTS_PATH = "objects.csv"
 LINKS_PATH = "links.csv"
 TRACKS_PATH = "tracks.csv"
 JSON = {
-    "name": names.PACKAGE_NAME,
+    "name": cmso.PACKAGE,
     "resources": [
         {
-            "name": names.OBJECTS_TABLE_NAME,
+            "name": cmso.OBJECTS_TABLE,
             "path": OBJECTS_PATH,
             "schema": {
                 "fields": [
-                    {"name": names.OBJECT_NAME,
+                    {"name": cmso.OBJECT_ID,
                      "constraints": {"unique": True}},
-                    {"name": names.FRAME_NAME},
-                    {"name": names.X_COORD_NAME},
-                    {"name": names.Y_COORD_NAME},
+                    {"name": cmso.FRAME_ID},
+                    {"name": cmso.X_COORD},
+                    {"name": cmso.Y_COORD},
                 ],
-                "primaryKey": names.OBJECT_NAME,
+                "primaryKey": cmso.OBJECT_ID,
             }
         },
         {
-            "name": names.LINKS_TABLE_NAME,
+            "name": cmso.LINKS_TABLE,
             "path": LINKS_PATH,
             "schema": {
-                "fields": [{"name": names.LINK_NAME},
-                           {"name": names.OBJECT_NAME}],
+                "fields": [{"name": cmso.LINK_ID},
+                           {"name": cmso.OBJECT_ID}],
                 "foreignKeys": [
-                    {"fields": names.OBJECT_NAME,
-                     "reference": {"fields": names.OBJECT_NAME,
-                                   "resource": names.OBJECTS_TABLE_NAME}}
+                    {"fields": cmso.OBJECT_ID,
+                     "reference": {"fields": cmso.OBJECT_ID,
+                                   "resource": cmso.OBJECTS_TABLE}}
                 ]
             }
         }
@@ -71,13 +71,13 @@ JSON = {
 
 CSV = {
     OBJECTS_PATH: [
-        [names.OBJECT_NAME, names.FRAME_NAME,
-         names.X_COORD_NAME, names.Y_COORD_NAME],
+        [cmso.OBJECT_ID, cmso.FRAME_ID,
+         cmso.X_COORD, cmso.Y_COORD],
         [0, 1, 0.4, 0.5],
         [1, 2, 0.5, 0.6],
     ],
     LINKS_PATH: [
-        [names.LINK_NAME, names.OBJECT_NAME],
+        [cmso.LINK_ID, cmso.OBJECT_ID],
         [0, 0],
         [0, 1],
     ],
@@ -132,7 +132,7 @@ class TestValidation(object):
                 self.__assert_raises(dp(d))
 
     def test_primary_key(self, dp):
-        obj_i, obj_res = self.__res_by_name(names.OBJECTS_TABLE_NAME)
+        obj_i, obj_res = self.__res_by_name(cmso.OBJECTS_TABLE)
         d = deepcopy(JSON)
         del d["resources"][obj_i]["schema"]["primaryKey"]
         self.__assert_raises(dp(d))
@@ -141,9 +141,9 @@ class TestValidation(object):
         self.__assert_raises(dp(d))
 
     def test_constraints(self, dp):
-        i, r = self.__res_by_name(names.OBJECTS_TABLE_NAME)
+        i, r = self.__res_by_name(cmso.OBJECTS_TABLE)
         j = [_ for (_, f) in enumerate(r["schema"]["fields"])
-             if f["name"] == names.OBJECT_NAME][0]
+             if f["name"] == cmso.OBJECT_ID][0]
         d = deepcopy(JSON)
         del d["resources"][i]["schema"]["fields"][j]["constraints"]
         self.__assert_raises(dp(d))
@@ -155,7 +155,7 @@ class TestValidation(object):
         self.__assert_raises(dp(d))
 
     def test_foreign_keys(self, dp):
-        i, r = self.__res_by_name(names.LINKS_TABLE_NAME)
+        i, r = self.__res_by_name(cmso.LINKS_TABLE)
         d = deepcopy(JSON)
         del d["resources"][i]["schema"]["foreignKeys"]
         self.__assert_raises(dp(d))
@@ -169,12 +169,12 @@ class TestValidation(object):
 
     def test_tracks(self, dp):
         tracks_res = {
-            "name": names.TRACKS_TABLE_NAME,
+            "name": cmso.TRACKS_TABLE,
             "path": TRACKS_PATH,
             "schema": {
                 "fields": [
-                    {"name": names.TRACK_NAME},
-                    {"name": names.LINK_NAME},
+                    {"name": cmso.TRACK_ID},
+                    {"name": cmso.LINK_ID},
                 ],
             },
         }


### PR DESCRIPTION
Both `names` (module) and `_NAME` (constant suffix) are a bit awkward and not very informative. This PR renames `names.py` to `cmso.py`, drops the `_NAME` suffix from constants and adds an `_ID` suffix where appropriate. With this change, the code now reads like:

```python
links_df.columns = [cmso.LINK_ID, cmso.OBJECT_ID]
```

Which stresses the fact that the corresponding property names are in the `cmso` namespace. Note that this only affects the library, not the package specs.

To test, check that the build stays green.