### PR TITLE
Units support

### DIFF
--- a/biotracks/cmso.py
+++ b/biotracks/cmso.py
@@ -39,3 +39,6 @@ FRAME_ID = "cmso_frame_id"
 OBJECT_ID = "cmso_object_id"
 LINK_ID = "cmso_link_id"
 TRACK_ID = "cmso_track_id"
+
+SPATIAL_UNIT = "cmso_spatial_unit"
+TIME_UNIT = "cmso_time_unit"

--- a/biotracks/cmso.py
+++ b/biotracks/cmso.py
@@ -40,5 +40,5 @@ OBJECT_ID = "cmso_object_id"
 LINK_ID = "cmso_link_id"
 TRACK_ID = "cmso_track_id"
 
-SPATIAL_UNIT = "cmso_spatial_unit"
+SPACE_UNIT = "cmso_space_unit"
 TIME_UNIT = "cmso_time_unit"

--- a/biotracks/config.py
+++ b/biotracks/config.py
@@ -24,18 +24,20 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # #L%
 
-"""\
-Define standard property names used in CMSO data packages.
-"""
+from configparser import ConfigParser
 
-OBJECTS_TABLE = "cmso_objects_table"
-LINKS_TABLE = "cmso_links_table"
-TRACKS_TABLE = "cmso_tracks_table"
+RELPATH = "biotracks.ini"
+TOP_LEVEL = "TOP_LEVEL_INFO"
+TRACKING = "TRACKING_DATA"
+DEFAULT_NAME = "cmso_tracks"
 
-X_COORD = "cmso_x_coord"
-Y_COORD = "cmso_y_coord"
-Z_COORD = "cmso_z_coord"
-FRAME_ID = "cmso_frame_id"
-OBJECT_ID = "cmso_object_id"
-LINK_ID = "cmso_link_id"
-TRACK_ID = "cmso_track_id"
+
+def get_conf(conf_fn=None):
+    conf = ConfigParser()
+    if conf_fn:
+        conf.read(conf_fn)
+    else:
+        for section in TOP_LEVEL, TRACKING:
+            conf.add_section(section)
+    conf.setdefault(TOP_LEVEL, {}).setdefault("name", DEFAULT_NAME)
+    return conf

--- a/biotracks/createdp.py
+++ b/biotracks/createdp.py
@@ -31,7 +31,7 @@ import re
 
 import datapackage
 from jsontableschema import infer
-from . import cmso
+from . import cmso, config
 from .utils import get_logger, mkdir_p
 
 
@@ -62,7 +62,7 @@ def to_json(dp):
 
 def create(reader, out_dir, log_level=None):
     logger = get_logger("createdp.create", level=log_level)
-    top_level_dict = reader.conf["TOP_LEVEL_INFO"]
+    top_level_dict = reader.conf[config.TOP_LEVEL]
     try:
         name = top_level_dict["name"]
     except KeyError:

--- a/biotracks/readfile.py
+++ b/biotracks/readfile.py
@@ -32,7 +32,7 @@ import pandas as pd
 import xlrd
 
 from .utils import get_logger
-from . import cmso
+from . import cmso, config
 
 
 class AbstractReader(metaclass=ABCMeta):
@@ -41,7 +41,7 @@ class AbstractReader(metaclass=ABCMeta):
         reader_name = self.__class__.__name__
         self.logger = get_logger(reader_name, level=log_level)
         self.fname = fname
-        self.conf = conf or {}
+        self.conf = conf or config.get_conf()
         self.logger.info('%s Reading "%s"', reader_name, fname)
         self._objects = None
         self._links = None
@@ -222,10 +222,10 @@ class TrackMateReader(AbstractReader):
 class CellProfilerReader(AbstractReader):
 
     def read(self):
-        self.x = self.conf["TRACKING_DATA"].get(cmso.X_COORD)
-        self.y = self.conf["TRACKING_DATA"].get(cmso.Y_COORD)
-        self.frame = self.conf["TRACKING_DATA"].get(cmso.FRAME_ID)
-        self.obj_id = self.conf["TRACKING_DATA"].get(cmso.OBJECT_ID)
+        self.x = self.conf[config.TRACKING].get(cmso.X_COORD)
+        self.y = self.conf[config.TRACKING].get(cmso.Y_COORD)
+        self.frame = self.conf[config.TRACKING].get(cmso.FRAME_ID)
+        self.obj_id = self.conf[config.TRACKING].get(cmso.OBJECT_ID)
         # parse the digits used for the tracking settings (e.g. 15)
         digits = self.x.split('_')[2]
         self.track_id = 'TrackObjects_Label_' + digits
@@ -320,9 +320,9 @@ class CellmiaReader(AbstractReader):
 
     def read(self):
         cellmia_link_id = "ID of track"
-        x = self.conf["TRACKING_DATA"].get(cmso.X_COORD)
-        y = self.conf["TRACKING_DATA"].get(cmso.Y_COORD)
-        frame_id = self.conf["TRACKING_DATA"].get(cmso.FRAME_ID)
+        x = self.conf[config.TRACKING].get(cmso.X_COORD)
+        y = self.conf[config.TRACKING].get(cmso.Y_COORD)
+        frame_id = self.conf[config.TRACKING].get(cmso.FRAME_ID)
         df = pd.read_csv(self.fname, sep=self.SEP, encoding=self.ENCODING,
                          usecols=[cellmia_link_id, frame_id, x, y])
         df.reset_index(inplace=True)
@@ -334,7 +334,7 @@ class CellmiaReader(AbstractReader):
 
 class TracksReader(object):
 
-    def __init__(self, fname, conf, log_level=None):
+    def __init__(self, fname, conf=None, log_level=None):
         logger = get_logger(self.__class__.__name__, level=log_level)
         _, ext = os.path.splitext(fname)
         if ext == '.xls':

--- a/biotracks/readfile.py
+++ b/biotracks/readfile.py
@@ -71,7 +71,7 @@ class TrackMateReader(AbstractReader):
                          self.root.attrib.get('version'))
         self.__model = self.root.find('Model')
         self.conf[config.TOP_LEVEL].setdefault(
-            cmso.SPATIAL_UNIT, self.__model.attrib["spatialunits"]
+            cmso.SPACE_UNIT, self.__model.attrib["spatialunits"]
         )
         self.conf[config.TOP_LEVEL].setdefault(
             cmso.TIME_UNIT, self.__model.attrib["timeunits"]

--- a/biotracks/readfile.py
+++ b/biotracks/readfile.py
@@ -69,6 +69,13 @@ class TrackMateReader(AbstractReader):
         self.root = ET.parse(self.fname).getroot()
         self.logger.info('Reading a TrackMate XML file version %s',
                          self.root.attrib.get('version'))
+        self.__model = self.root.find('Model')
+        self.conf[config.TOP_LEVEL].setdefault(
+            cmso.SPATIAL_UNIT, self.__model.attrib["spatialunits"]
+        )
+        self.conf[config.TOP_LEVEL].setdefault(
+            cmso.TIME_UNIT, self.__model.attrib["timeunits"]
+        )
         spots_dict = self.read_spots()
         self._objects = pd.DataFrame(
             [[k, v[0], v[1], v[2]] for k, v in spots_dict.items()],
@@ -79,7 +86,7 @@ class TrackMateReader(AbstractReader):
 
     def read_spots(self):
         spots_dict = {}
-        for child in self.root.find('Model'):
+        for child in self.__model:
             if child.tag == 'AllSpots':
                 spots = child
                 for spot_in_frame in spots.getchildren():
@@ -95,7 +102,7 @@ class TrackMateReader(AbstractReader):
     def read_edges(self, spots_dict):
         edges_dict = {}
         edge_id = 0
-        for child in self.root.find('Model'):
+        for child in self.__model:
             if child.tag == 'AllTracks':
                 tracks = child
                 for track in tracks.getchildren():

--- a/biotracks/readfile.py
+++ b/biotracks/readfile.py
@@ -218,10 +218,10 @@ class TrackMateReader(AbstractReader):
 class CellProfilerReader(AbstractReader):
 
     def read(self):
-        self.x = self.conf.get(cmso.X_COORD)
-        self.y = self.conf.get(cmso.Y_COORD)
-        self.frame = self.conf.get(cmso.FRAME_ID)
-        self.obj_id = self.conf.get(cmso.OBJECT_ID)
+        self.x = self.conf["TRACKING_DATA"].get(cmso.X_COORD)
+        self.y = self.conf["TRACKING_DATA"].get(cmso.Y_COORD)
+        self.frame = self.conf["TRACKING_DATA"].get(cmso.FRAME_ID)
+        self.obj_id = self.conf["TRACKING_DATA"].get(cmso.OBJECT_ID)
         # parse the digits used for the tracking settings (e.g. 15)
         digits = self.x.split('_')[2]
         self.track_id = 'TrackObjects_Label_' + digits
@@ -316,9 +316,9 @@ class CellmiaReader(AbstractReader):
 
     def read(self):
         cellmia_link_id = "ID of track"
-        x = self.conf.get(cmso.X_COORD)
-        y = self.conf.get(cmso.Y_COORD)
-        frame_id = self.conf.get(cmso.FRAME_ID)
+        x = self.conf["TRACKING_DATA"].get(cmso.X_COORD)
+        y = self.conf["TRACKING_DATA"].get(cmso.Y_COORD)
+        frame_id = self.conf["TRACKING_DATA"].get(cmso.FRAME_ID)
         df = pd.read_csv(self.fname, sep=self.SEP, encoding=self.ENCODING,
                          usecols=[cellmia_link_id, frame_id, x, y])
         df.reset_index(inplace=True)

--- a/biotracks/readfile.py
+++ b/biotracks/readfile.py
@@ -38,10 +38,10 @@ from . import cmso
 class AbstractReader(metaclass=ABCMeta):
 
     def __init__(self, fname, conf=None, log_level=None):
-        self.fname = fname
-        self.conf = conf or {}
         reader_name = self.__class__.__name__
         self.logger = get_logger(reader_name, level=log_level)
+        self.fname = fname
+        self.conf = conf or {}
         self.logger.info('%s Reading "%s"', reader_name, fname)
         self._objects = None
         self._links = None
@@ -334,9 +334,11 @@ class TracksReader(object):
         logger = get_logger(self.__class__.__name__, level=log_level)
         _, ext = os.path.splitext(fname)
         if ext == '.xls':
-            self.reader = IcyReader(fname, log_level=log_level)
+            self.reader = IcyReader(fname, conf=conf, log_level=log_level)
         elif ext == '.xml':
-            self.reader = TrackMateReader(fname, log_level=log_level)
+            self.reader = TrackMateReader(
+                fname, conf=conf, log_level=log_level
+            )
         elif ext == '.csv':
             self.reader = CellProfilerReader(
                 fname, conf=conf, log_level=log_level
@@ -352,6 +354,10 @@ class TracksReader(object):
 
     def read(self):
         self.reader.read()
+
+    @property
+    def conf(self):
+        return self.reader.conf
 
     @property
     def objects(self):

--- a/biotracks/readfile.py
+++ b/biotracks/readfile.py
@@ -52,10 +52,14 @@ class AbstractReader(metaclass=ABCMeta):
 
     @property
     def objects(self):
+        if self._objects is None:
+            self.read()
         return self._objects
 
     @property
     def links(self):
+        if self._links is None:
+            self.read()
         return self._links
 
 

--- a/biotracks/utils.py
+++ b/biotracks/utils.py
@@ -24,6 +24,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # #L%
 
+import os
+import errno
 import logging
 
 
@@ -75,3 +77,12 @@ def get_logger(name, level=None, f=None, mode='a'):
     handler.setFormatter(logging.Formatter(LOG_FORMAT))
     logger.addHandler(handler)
     return logger
+
+
+def mkdir_p(*paths):
+    for p in paths:
+        try:
+            os.makedirs(p)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise

--- a/examples/TrackMate/example_1/dp/dp.json
+++ b/examples/TrackMate/example_1/dp/dp.json
@@ -2,6 +2,8 @@
     "author": "paola masuzzo",
     "author_email": "paola.masuzzo@email.com",
     "author_institute": "VIB",
+    "cmso_spatial_unit": "pixel",
+    "cmso_time_unit": "sec",
     "name": "cmso_tracks",
     "resources": [
         {

--- a/examples/TrackMate/example_1/dp/dp.json
+++ b/examples/TrackMate/example_1/dp/dp.json
@@ -2,7 +2,7 @@
     "author": "paola masuzzo",
     "author_email": "paola.masuzzo@email.com",
     "author_institute": "VIB",
-    "cmso_spatial_unit": "pixel",
+    "cmso_space_unit": "pixel",
     "cmso_time_unit": "sec",
     "name": "cmso_tracks",
     "resources": [

--- a/examples/TrackMate/example_2/dp/dp.json
+++ b/examples/TrackMate/example_2/dp/dp.json
@@ -2,6 +2,8 @@
     "author": "paola masuzzo",
     "author_email": "paola.masuzzo@email.com",
     "author_institute": "VIB",
+    "cmso_spatial_unit": "pixel",
+    "cmso_time_unit": "sec",
     "name": "cmso_tracks",
     "resources": [
         {

--- a/examples/TrackMate/example_2/dp/dp.json
+++ b/examples/TrackMate/example_2/dp/dp.json
@@ -2,7 +2,7 @@
     "author": "paola masuzzo",
     "author_email": "paola.masuzzo@email.com",
     "author_institute": "VIB",
-    "cmso_spatial_unit": "pixel",
+    "cmso_space_unit": "pixel",
     "cmso_time_unit": "sec",
     "name": "cmso_tracks",
     "resources": [

--- a/scripts/create_dpkg.py
+++ b/scripts/create_dpkg.py
@@ -30,7 +30,6 @@ Convert a tracking software output file to a datapackage representation.
 
 import os
 import sys
-import configparser
 import argparse
 
 import numpy as np
@@ -41,10 +40,10 @@ import biotracks.plot as plot
 import biotracks.pushtopandas as pushtopandas
 import biotracks.readfile as readfile
 import biotracks.cmso as cmso
+import biotracks.config as config
 from biotracks.utils import get_log_level, get_logger
 
 
-DEFAULT_CONFIG_BASENAME = 'biotracks.ini'
 DEFAULT_OUTPUT_BASENAME = 'dp'
 
 
@@ -73,14 +72,12 @@ def main(argv):
     if args.out_dir is None:
         args.out_dir = DEFAULT_OUTPUT_BASENAME
     if not args.config:
-        args.config = os.path.join(input_dir, DEFAULT_CONFIG_BASENAME)
+        args.config = os.path.join(input_dir, config.RELPATH)
         logger.info('Trying default config file location: "%s"', args.config)
     if not os.path.isfile(args.config):
-        logger.info('Config file not present, using defaults')
-        conf = {'TOP_LEVEL_INFO': {'name': cmso.PACKAGE}, 'TRACKING_DATA': {}}
-    else:
-        conf = configparser.ConfigParser()
-        conf.read(args.config)
+        logger.info('Config file not found, using defaults')
+        args.config = None
+    conf = config.get_conf(conf_fn=args.config)
 
     joint_id = cmso.OBJECT_ID
     link_id = cmso.LINK_ID

--- a/scripts/create_dpkg.py
+++ b/scripts/create_dpkg.py
@@ -83,13 +83,10 @@ def main(argv):
         logger.info('Trying default config file location: "%s"', args.config)
     if not os.path.isfile(args.config):
         logger.info('Config file not present, using defaults')
-        top_level_dict = {'name': cmso.PACKAGE}
-        track_dict = {}
+        conf = {'TOP_LEVEL_INFO': {'name': cmso.PACKAGE}, 'TRACKING_DATA': {}}
     else:
         conf = configparser.ConfigParser()
         conf.read(args.config)
-        top_level_dict = conf['TOP_LEVEL_INFO']
-        track_dict = conf['TRACKING_DATA']
 
     joint_id = cmso.OBJECT_ID
     link_id = cmso.LINK_ID
@@ -97,7 +94,7 @@ def main(argv):
 
     # read input file
     reader = readfile.TracksReader(
-        args.track_fn, conf=track_dict, log_level=args.log_level
+        args.track_fn, conf=conf, log_level=args.log_level
     )
     reader.read()
     dict_ = {'objects': reader.objects, 'links': reader.links}
@@ -110,7 +107,9 @@ def main(argv):
         v.to_csv(directory + os.sep + k + '.csv',
                  index=False, quoting=csv.QUOTE_NONE)
     logger.info('tabular files written to "%s"', directory)
-    dp = createdp.create_dpkg(top_level_dict, dict_, directory, joint_id)
+    dp = createdp.create_dpkg(
+        conf['TOP_LEVEL_INFO'], dict_, directory, joint_id
+    )
     # write the data package representation
     with open(directory + os.sep + 'dp.json', 'w') as f_json:
         f_json.write(to_json(dp) + '\n')

--- a/scripts/create_dpkg.py
+++ b/scripts/create_dpkg.py
@@ -95,10 +95,12 @@ def main(argv):
     link_id = cmso.LINK_ID
     track_id = cmso.TRACK_ID
 
-    # read file - returns a dictionary with objects and links
-    dict_ = readfile.read_file(
-        args.track_fn, track_dict, log_level=args.log_level
+    # read input file
+    reader = readfile.TracksReader(
+        args.track_fn, conf=track_dict, log_level=args.log_level
     )
+    reader.read()
+    dict_ = {'objects': reader.objects, 'links': reader.links}
     # make directory for the csv and the dp representation
     directory = args.out_dir
     if not os.path.exists(directory):

--- a/tests/test_createdp.py
+++ b/tests/test_createdp.py
@@ -25,12 +25,11 @@
 # #L%
 
 import os
-import configparser
 
 import datapackage
 import pytest
 
-from biotracks import createdp, readfile
+from biotracks import createdp, readfile, config
 from .common import EXAMPLES_DIR, RELPATHS
 
 
@@ -42,9 +41,8 @@ def data(tmpdir):
         dp_fn = os.path.join(exp_dp_dir, 'dp.json')
         dp = datapackage.DataPackage(dp_fn)
         in_fn = os.path.join(base_dir, RELPATHS[fmt][-1])
-        conf_fn = os.path.join(base_dir, 'biotracks.ini')
-        conf = configparser.ConfigParser()
-        conf.read(conf_fn)
+        conf_fn = os.path.join(base_dir, config.RELPATH)
+        conf = config.get_conf(conf_fn=conf_fn)
         reader = readfile.TracksReader(in_fn, conf=conf)
         reader.read()
         return {'reader': reader, 'dp': dp, 'dp_dir': str(tmpdir)}
@@ -69,6 +67,6 @@ class TestCreatedp(object):
     def __check_dps(self, d):
         dp = createdp.create(d['reader'], d['dp_dir'])
         assert dp.to_dict() == d['dp'].to_dict()
-        d['reader'].conf['TOP_LEVEL_INFO']['name'] = "CMSO_TRACKS"
+        d['reader'].conf[config.TOP_LEVEL]['name'] = 'CMSO_TRACKS'
         with pytest.raises(ValueError):
             createdp.create(d['reader'], d['dp_dir'])

--- a/tests/test_pushtopandas.py
+++ b/tests/test_pushtopandas.py
@@ -25,12 +25,11 @@
 # #L%
 
 import os
-import configparser
 
 import pandas as pd
 import pytest
 
-from biotracks import cmso
+from biotracks import cmso, config
 from biotracks.pushtopandas import push_to_pandas
 from .common import (
     EXAMPLES_DIR, RELPATHS, get_obj_dict, get_link_dict, get_track_dict
@@ -46,10 +45,8 @@ def data():
         d['obj_df'] = pd.read_csv(os.path.join(dp_dir, 'objects.csv'))
         d['links_df'] = pd.read_csv(os.path.join(dp_dir, 'links.csv'))
         d['tracks_df'] = pd.read_csv(os.path.join(dp_dir, 'tracks.csv'))
-        conf_fn = os.path.join(base_dir, 'biotracks.ini')
-        conf = configparser.ConfigParser()
-        conf.read(conf_fn)
-        d['conf'] = conf
+        conf_fn = os.path.join(base_dir, config.RELPATH)
+        d['conf'] = config.get_conf(conf_fn=conf_fn)
         return d
     return make_data
 

--- a/tests/test_readfile.py
+++ b/tests/test_readfile.py
@@ -64,14 +64,14 @@ class TestReadFile(object):
         self.__check_dicts(d)
         top_level = d['reader'].conf[config.TOP_LEVEL]
         from_source = {}
-        for k in cmso.SPATIAL_UNIT, cmso.TIME_UNIT:
+        for k in cmso.SPACE_UNIT, cmso.TIME_UNIT:
             assert k in top_level
             from_source[k] = top_level[k]
         # check override
-        spatial_unit = from_source[cmso.SPATIAL_UNIT] + "_"
-        top_level[cmso.SPATIAL_UNIT] = spatial_unit
+        spatial_unit = from_source[cmso.SPACE_UNIT] + "_"
+        top_level[cmso.SPACE_UNIT] = spatial_unit
         d['reader'].read()
-        assert top_level[cmso.SPATIAL_UNIT] == spatial_unit
+        assert top_level[cmso.SPACE_UNIT] == spatial_unit
 
     def __check_dicts(self, d):
         reader = d['reader']

--- a/tests/test_readfile.py
+++ b/tests/test_readfile.py
@@ -60,7 +60,18 @@ class TestReadFile(object):
         self.__check_dicts(data('CellProfiler'))
 
     def test_trackmate(self, data):
-        self.__check_dicts(data('TrackMate'))
+        d = data('TrackMate')
+        self.__check_dicts(d)
+        top_level = d['reader'].conf[config.TOP_LEVEL]
+        from_source = {}
+        for k in cmso.SPATIAL_UNIT, cmso.TIME_UNIT:
+            assert k in top_level
+            from_source[k] = top_level[k]
+        # check override
+        spatial_unit = from_source[cmso.SPATIAL_UNIT] + "_"
+        top_level[cmso.SPATIAL_UNIT] = spatial_unit
+        d['reader'].read()
+        assert top_level[cmso.SPATIAL_UNIT] == spatial_unit
 
     def __check_dicts(self, d):
         reader = d['reader']

--- a/tests/test_readfile.py
+++ b/tests/test_readfile.py
@@ -42,7 +42,7 @@ def data():
         conf_fn = os.path.join(base_dir, "biotracks.ini")
         conf = configparser.ConfigParser()
         conf.read(conf_fn)
-        reader = readfile.TracksReader(in_fn, conf=conf['TRACKING_DATA'])
+        reader = readfile.TracksReader(in_fn, conf=conf)
         d = {'reader': reader}
         for k in 'objects', 'links':
             d['%s_path' % k] = os.path.join(base_dir, 'dp', '%s.csv' % k)

--- a/tests/test_readfile.py
+++ b/tests/test_readfile.py
@@ -67,9 +67,6 @@ class TestReadFile(object):
     def __check_dicts(self, d):
         reader = d['reader']
         for name in 'objects', 'links':
-            assert getattr(reader, name) is None
-        reader.read()
-        for name in 'objects', 'links':
             assert type(getattr(reader, name) is pd.DataFrame)
         obj_id, link_id = cmso.OBJECT_ID, cmso.LINK_ID
         exp_link_dict = get_link_dict(

--- a/tests/test_readfile.py
+++ b/tests/test_readfile.py
@@ -25,12 +25,11 @@
 # #L%
 
 import os
-import configparser
 
 import pandas as pd
 import pytest
 
-from biotracks import readfile, cmso
+from biotracks import readfile, cmso, config
 from .common import EXAMPLES_DIR, RELPATHS, get_obj_dict, get_link_dict
 
 
@@ -39,9 +38,8 @@ def data():
     def make_data(fmt):
         base_dir = os.path.join(EXAMPLES_DIR, fmt, *RELPATHS[fmt][:-1])
         in_fn = os.path.join(base_dir, RELPATHS[fmt][-1])
-        conf_fn = os.path.join(base_dir, "biotracks.ini")
-        conf = configparser.ConfigParser()
-        conf.read(conf_fn)
+        conf_fn = os.path.join(base_dir, config.RELPATH)
+        conf = config.get_conf(conf_fn=conf_fn)
         reader = readfile.TracksReader(in_fn, conf=conf)
         d = {'reader': reader}
         for k in 'objects', 'links':

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -31,13 +31,13 @@ from copy import deepcopy
 import pytest
 from datapackage.exceptions import ValidationError
 
-from biotracks import validation, cmso
+from biotracks import validation, cmso, config
 
 OBJECTS_PATH = "objects.csv"
 LINKS_PATH = "links.csv"
 TRACKS_PATH = "tracks.csv"
 JSON = {
-    "name": cmso.PACKAGE,
+    "name": config.DEFAULT_NAME,
     "resources": [
         {
             "name": cmso.OBJECTS_TABLE,


### PR DESCRIPTION
Addresses #9. Also fixes a couple of issues along the way since they were making it cumbersome to add new stuff. Individual commit messages provide a summary of these changes.

To test, check that the Travis build passes and that code changes make sense (looking at individual commits one by one might help here).

Some highlights:

* 6238f9e adds a bottom-level abstract reader that specifies the protocol (like `IFormatReader` in BF) and adds a top-level delegating reader that does the mapping from formats to specific readers (like `ImageReader` in BF)

* 561463f solves a number of issues with `createdp`, mainly the fact that it was relying on already existing csv files (this was provided by the calling script, meaning the API call would have failed unless the user was prepared for this) and that csv files were being read back to infer types (that can be done in-memory while we still hold a reference to the dataframes)

* 063f1f6 allows to remove more hardcoded names by centralizing them to a module and simplifies interaction with the configuration