### PR TITLE
Ensure datapackage<1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-datapackage
+datapackage<1.0
 jsontableschema
 jsontableschema-pandas


### PR DESCRIPTION
Hi! Frictionless Data's `datapackage-py` is going to reach v1 release and it could be breaking for some software (we use SemVer). Adding `<1.0` version requirement.